### PR TITLE
perf: フォントの読み込みを style.css に

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blog - kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 

--- a/index.html
+++ b/index.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 

--- a/mario.html
+++ b/mario.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mario - kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 

--- a/others.html
+++ b/others.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Others - kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 

--- a/posts/hajimete.html
+++ b/posts/hajimete.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>最初の投稿 - kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 

--- a/posts/mariohukkisitai.html
+++ b/posts/mariohukkisitai.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>マリオ64RTAに復帰したい話 - kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 

--- a/posts/template.html
+++ b/posts/template.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>投稿タイトル - kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 

--- a/rust.html
+++ b/rust.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Rust - kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap");
+
 /* ─── Variables ─────────────────────────────────────────── */
 :root {
     --bg: #0e0e0e;

--- a/valorant.html
+++ b/valorant.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Valorant - kimchi64.dev</title>
     <link rel="icon" href="https://avatars.githubusercontent.com/u/183417534?v=4">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
-        rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 


### PR DESCRIPTION
すべての HTML ファイルに重複していた `<link>` タグのフォントリクエストを style.css に共通化しました
(下になんでこれのほうがいいのか書きます．読みたくなければ読まなくて大丈夫．聞きたいことがあれば VC や DM で聞いてください． Claude に聞いてもいい)

----

```html
    <link rel="preconnect" href="https://fonts.googleapis.com">
    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
    <link
        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap"
        rel="stylesheet">
```

まず，上のような今まで書いていたフォント読み込みは以下の問題があります．

- すべての HTML ファイルに重複 = その HTML を開くたびにブラウザがフォントをダウンロードしてしまうので無駄が発生してしまう
   - 今のブラウザは賢いため，キャッシュ (一時的に手元に残しておくこと) しています．なので私が言っているこの無駄は「今は」発生していません
- フォントを変更したいときにすべての HTML を変更しないと変更がうまく効かなくなります (面倒だよね)

なので，これを `style.css` に移動させました．なぜ移動させるといいのかは

- この  `style.css` を読み込むだけでそのフォントが適用されるようになる
- フォントを変更したいときはここの URL を変えるだけで済むように

```css
@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+JP:wght@300;400;500&display=swap");
```

`@import` がどういうものなのかは MDN を読んだり Claude に聞いてみてください，

https://developer.mozilla.org/ja/docs/Web/CSS/Reference/At-rules/@import

